### PR TITLE
Implement initial support for parentheses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build_debug/
+build/
+*.out

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 CC=g++
-CXX_FLAGS=-Wall -Werror -std=c++17 -g
+CXX_FLAGS=-Wall -Werror -std=c++17 -O2
 
 TARGET= calc.out
 
 
-$(TARGET):
-	$(CC) $(CXX_FLAGS) src/*.cpp -o $(TARGET)
-
-all:
-	$(TARGET)
 	
+all:
+	rm -rf build/ && mkdir build/
+	$(CC) $(CXX_FLAGS) src/*.cpp -o build/$(TARGET)
+
+debug:
+	rm -rf build_debug/ && mkdir build_debug/
+	$(CC) $(CXX_FLAGS) -DTOKEN_DEBUG src/*.cpp -o build_debug/$(TARGET)
+
 clean:
 	rm *.out
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -28,7 +28,7 @@ void Lexer::lex() {
   while (!atEnd()) {
     lexOneToken();
   }
-  addToken(Token(TOKEN_EOF, "eof", 0, 0, std::nullopt));
+  addToken(Token(TOKEN_EOF, "eof", startPos_, curPos_, std::nullopt));
 }
 
 void Lexer::lexOneToken() {
@@ -83,6 +83,28 @@ void Lexer::lexOneToken() {
     }
     addToken(Token(TOKEN_SLASH, "/", startPos_, startPos_, std::nullopt));
     currTokenKind_ = TOKEN_SLASH;
+    break;
+  case '(':
+    currTokenError_ = false;
+    if (prevTokenError_ && !currTokenError_) {
+      curPos_--;
+      addToken(logError("unknown token encountered in stream"));
+      prevTokenError_ = currTokenError_ = false;
+      startPos_ = curPos_;
+    }
+    addToken(Token(TOKEN_LPAREN, "(", startPos_, startPos_, std::nullopt));
+    currTokenKind_ = TOKEN_LPAREN;
+    break;
+  case ')':
+    currTokenError_ = false;
+    if (prevTokenError_ && !currTokenError_) {
+      curPos_--;
+      addToken(logError("unknown token encountered in stream"));
+      prevTokenError_ = currTokenError_ = false;
+      startPos_ = curPos_;
+    }
+    addToken(Token(TOKEN_RPAREN, ")", startPos_, startPos_, std::nullopt));
+    currTokenKind_ = TOKEN_RPAREN;
     break;
   case ' ':
   case '\t':

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -20,6 +20,9 @@ enum TokenKind {
 
   // number
   TOKEN_NUM,
+
+  TOKEN_LPAREN,
+  TOKEN_RPAREN,
   TOKEN_ERROR,
   TOKEN_EOF,
 };
@@ -57,6 +60,13 @@ public:
       : hadError(false), src_(src), startPos_(0), curPos_(0),
         prevTokenError_(false), currTokenError_(false) {}
   void lex();
+
+  void dumpAllTokens() {
+    for (auto token : tokenList_) {
+      token.dump();
+      std::cerr << "\n";
+    }
+  }
 
   std::vector<struct Diagnostic> GetDiagnosticList() { return diagnostics_; }
   std::vector<struct Token> GetTokenList() { return tokenList_; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,9 @@ int main() {
     auto srcStr = std::string(src);
     Lexer lexer(srcStr);
     lexer.lex();
+#ifdef TOKEN_DEBUG
+    lexer.dumpAllTokens();
+#endif
     if (!lexer.hadError) {
       std::cerr << "lexed successfully \n";
     }

--- a/src/parser.h
+++ b/src/parser.h
@@ -22,8 +22,11 @@ private:
   struct Token peek();
   struct Token previous();
   int getPrecedence();
+  bool consume(enum TokenKind tk, std::string errMsg);
   bool check(enum TokenKind expected);
   std::unique_ptr<Expr> parseUnary();
+  std::unique_ptr<Expr> parsePrimaryExpr();
+  std::unique_ptr<Expr> parseParen();
   std::unique_ptr<Expr> parseBinary(int prec, std::unique_ptr<Expr> lhs);
   std::unique_ptr<Expr> expression();
 


### PR DESCRIPTION
Implements basic support for parentheses and grouped expressions.
Still has a parse error when a stray right parenthesis is encountered or stray parenthesis is left at the end of the source string.


Resolves #2 .